### PR TITLE
Apply word-break: break-all style to generated links

### DIFF
--- a/plugin/src/main/resources/template/layout.html
+++ b/plugin/src/main/resources/template/layout.html
@@ -13,6 +13,9 @@
     padding: 0 0.5em;
     border-bottom: 1px solid #ebeae6;
     }
+    .library a {
+    word-break: break-all;
+    }
     .title {
     font-size: 129%;
     font-weight: bold;


### PR DESCRIPTION
Tweak CSS to make URLs wrapped at display width.

| [Before] Link text is not wrapped | [Before] The page can be scrolled horizontally |  [After] Link text is wrapped |
|---|---|---|
| <img src="https://user-images.githubusercontent.com/2552365/136699742-0c027eb0-1e4c-4798-ad02-e7293406343a.png" width=200 /> | <img src="https://user-images.githubusercontent.com/2552365/136699628-f84f0c15-80f9-4edf-9b16-3383f8a42ebf.png" width=200 /> | <img src="https://user-images.githubusercontent.com/2552365/136699821-01ea8d3a-662b-4888-a3ce-c6a5ca0e8d5b.png" width=200 /> |

